### PR TITLE
5-aws-s3: Adjust file import paths with s3 changes

### DIFF
--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,7 +1,7 @@
 const API_PATHS = {
   product: 'https://scdcrvkblg.execute-api.us-east-1.amazonaws.com/dev',
   order: 'https://scdcrvkblg.execute-api.us-east-1.amazonaws.com/dev',
-  import: 'https://scdcrvkblg.execute-api.us-east-1.amazonaws.com/dev',
+  import: 'https://8iv7ta4g42.execute-api.us-east-1.amazonaws.com/dev',
   bff: 'https://scdcrvkblg.execute-api.us-east-1.amazonaws.com/dev',
   cart: 'https://scdcrvkblg.execute-api.us-east-1.amazonaws.com/dev',
 };


### PR DESCRIPTION
- FE Cloudfront App: https://d1uytctue365ki.cloudfront.net/
- Backend PR: https://github.com/oddestdan/services-aws-serverless/pull/3

---

Main tasks
- [x] Updated file import paths to connect with `importProductsFile` Lambda API Gateway URL -- https://8iv7ta4g42.execute-api.us-east-1.amazonaws.com/dev/import